### PR TITLE
Add Windows portable installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ commands:
     job-retry-all                                 retry all failed jobs
 ```
 
+Portable Windows Installation
+-----------------------------
+
+For a quick portable setup on Windows, run `portable_install.bat`. The script
+downloads a standalone Python distribution, installs the required packages and
+creates `run_facefusion.bat` inside `D:\facefusion`. After it completes, launch
+FaceFusion by double clicking `run_facefusion.bat`.
+
 
 Documentation
 -------------

--- a/portable_install.bat
+++ b/portable_install.bat
@@ -1,0 +1,37 @@
+@echo off
+setlocal
+set "DEST=D:\facefusion"
+
+echo Installing FaceFusion portable version to %DEST%
+
+if not exist "%DEST%" (
+    mkdir "%DEST%"
+)
+
+rem Copy repository files
+xcopy /E /I /Y "%~dp0" "%DEST%\source" >nul
+
+cd /d "%DEST%\source"
+
+set "PYVER=3.10.11"
+set "PY_URL=https://www.python.org/ftp/python/%PYVER%/python-%PYVER%-embed-amd64.zip"
+set "PY_ARCHIVE=%DEST%\python.zip"
+
+if not exist "%DEST%\python" (
+    echo Downloading portable Python %PYVER%...
+    powershell -Command "Invoke-WebRequest -Uri '%PY_URL%' -OutFile '%PY_ARCHIVE%'"
+    powershell -Command "Expand-Archive -LiteralPath '%PY_ARCHIVE%' -DestinationPath '%DEST%\python'"
+    del "%PY_ARCHIVE%"
+)
+
+set "PATH=%DEST%\python;%PATH%"
+%DEST%\python\python.exe -m ensurepip
+%DEST%\python\python.exe -m pip install -r requirements.txt
+%DEST%\python\python.exe install.py --onnxruntime default --skip-conda
+
+copy "%~dp0run_facefusion.bat" "%DEST%\run_facefusion.bat" >nul
+
+echo Installation complete.
+echo Use run_facefusion.bat inside %DEST% to start FaceFusion.
+pause
+endlocal

--- a/run_facefusion.bat
+++ b/run_facefusion.bat
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+set "APP_DIR=%~dp0source"
+"%~dp0python\python.exe" "%APP_DIR%\facefusion.py" run %*
+endlocal


### PR DESCRIPTION
## Summary
- add `portable_install.bat` script to install a portable copy to `D:\facefusion`
- provide `run_facefusion.bat` helper for launching
- document the new script in the README

## Testing
- `pytest -q` *(fails: 32 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c42e8fb38832bbca7bdaf0293a2ae